### PR TITLE
remove 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - 2.7
-  - 3.3
+  - 3.4
   - 3.5
   - 3.6
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
-  - 3.4
   - 3.5
   - 3.6
   - nightly


### PR DESCRIPTION
Travis CI no longer supports Python2.6 and 3.3 because of underlying library requirements.
2.6 and 3.3 have actually reach end-of-life as per [https://devguide.python.org/#status-of-python-branches](https://devguide.python.org/#status-of-python-branches)
Most libraries have dropped support for them.

Tests on other pull requests are currently failing due to 2.6 and 3.3